### PR TITLE
Fix and refactor deploy task in Rakefile. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ build/*
 *.pem
 *.crx
 *.ignore
+
+# .github-upload-token stores OAuth token, used by github_downloads gem
+.github-upload-token


### PR DESCRIPTION
The `deploy` task now uses the `github_downloads` gem for uploading archives to GitHub. 
